### PR TITLE
ci: add GitHub Actions workflow for tests and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: Test & Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .: {}
 
+  packages/landing:
+    dependencies:
+      '@cafe-listo/shared':
+        specifier: workspace:*
+        version: link:../shared
+
+  packages/mcp-server:
+    dependencies:
+      '@cafe-listo/shared':
+        specifier: workspace:*
+        version: link:../shared
+
   packages/mobile:
     dependencies:
       '@cafe-listo/shared':
@@ -796,7 +808,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs on push to `main` and on all PRs
- Runs `pnpm typecheck` and `pnpm test` across all workspace packages
- Uses pnpm v10, Node 20, with dependency caching

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)